### PR TITLE
Fix SetWindowLong error for x86

### DIFF
--- a/src/Files.App.CsWin32/Files.App.CsWin32.csproj
+++ b/src/Files.App.CsWin32/Files.App.CsWin32.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
         <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
         <IsTrimmable>true</IsTrimmable>
+        <DefineConstants Condition="'$(Platform)' == 'x86'">X86</DefineConstants>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Files.App.CsWin32/NativeMethods.txt
+++ b/src/Files.App.CsWin32/NativeMethods.txt
@@ -99,6 +99,7 @@ SendMessage
 IsWindowVisible
 COPYDATASTRUCT
 SetWindowLongPtr
+SetWindowLong
 GetDpiForWindow
 CallWindowProc
 MINMAXINFO

--- a/src/Files.App.CsWin32/Windows.Win32.Extras.cs
+++ b/src/Files.App.CsWin32/Windows.Win32.Extras.cs
@@ -17,4 +17,16 @@ namespace Windows.Win32
 		[UnmanagedFunctionPointer(CallingConvention.Winapi)]
 		public delegate LRESULT WNDPROC(HWND hWnd, uint msg, WPARAM wParam, LPARAM lParam);
 	}
+
+	public static partial class PInvoke
+	{
+		public static nint SetWindowLongPlat(HWND hWnd, UI.WindowsAndMessaging.WINDOW_LONG_PTR_INDEX nIndex, nint dwNewLong)
+		{
+#if X86
+			return SetWindowLong(hWnd, nIndex, (int)dwNewLong);
+#else
+			return SetWindowLongPtr(hWnd, nIndex, dwNewLong);
+#endif
+		}
+	}
 }

--- a/src/Files.App/Data/Items/WindowEx.cs
+++ b/src/Files.App/Data/Items/WindowEx.cs
@@ -102,7 +102,7 @@ namespace Files.App.Data.Items
 
 			_newWndProc = new(NewWindowProc);
 			var pNewWndProc = Marshal.GetFunctionPointerForDelegate(_newWndProc);
-			var pOldWndProc = PInvoke.SetWindowLongPtr(new(WindowHandle), WINDOW_LONG_PTR_INDEX.GWL_WNDPROC, pNewWndProc);
+			var pOldWndProc = PInvoke.SetWindowLongPlat(new(WindowHandle), WINDOW_LONG_PTR_INDEX.GWL_WNDPROC, pNewWndProc);
 			_oldWndProc = Marshal.GetDelegateForFunctionPointer<WNDPROC>(pOldWndProc);
 
 			Closed += WindowEx_Closed;

--- a/src/Files.App/ViewModels/UserControls/Previews/ShellPreviewViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Previews/ShellPreviewViewModel.cs
@@ -249,11 +249,11 @@ namespace Files.App.ViewModels.Previews
 					(uint)Marshal.SizeOf(dwAttrib));
 
 				if (isOfficePreview)
-					PInvoke.SetWindowLongPtr(new((nint)hwnd), WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE, 0);
+					PInvoke.SetWindowLongPlat(new((nint)hwnd), WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE, 0);
 			}
 			else
 			{
-				PInvoke.SetWindowLongPtr(new((nint)hwnd), WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE, (nint)(WINDOW_EX_STYLE.WS_EX_LAYERED | WINDOW_EX_STYLE.WS_EX_COMPOSITED));
+				PInvoke.SetWindowLongPlat(new((nint)hwnd), WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE, (nint)(WINDOW_EX_STYLE.WS_EX_LAYERED | WINDOW_EX_STYLE.WS_EX_COMPOSITED));
 
 				var dwAttrib = Convert.ToUInt32(true);
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix the SetWindowLong error for x86 architecture by introducing a platform-specific method.